### PR TITLE
🐛 fix: brand logo 경로 수정

### DIFF
--- a/includes/header.html
+++ b/includes/header.html
@@ -2,7 +2,7 @@
   <div class="container">
 
     <!-- Brand -->
-    <a class="navbar-brand" href="/"><i class="fas fa-floppy-disk fa-fw"></i> Conneclife</a>
+    <a class="navbar-brand" href="index"><i class="fas fa-floppy-disk fa-fw"></i> Conneclife</a>
 
     <!-- Toggle -->
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#charadexnav">


### PR DESCRIPTION
## 관련 issue

#1

## 내용 요약

상위 header(navbar)에서 로고(brand) 클릭시 404 페이지가 뜨던 오류 수정

## 변경 사항

- Conneclife 로고(brand) 클릭 시 이동 경로가 `/`에서 `href`로 변경

## 참고 자료