### PR TITLE
[feat] 디스코드/토이하우스 하이퍼링크 삭제

### DIFF
--- a/includes/header.html
+++ b/includes/header.html
@@ -22,9 +22,6 @@
           <div class="dropdown-menu dropdown-menu-right">
             <a class="dropdown-item" href="world">About World</a>
             <a class="dropdown-item" href="species">About Species</a>
-            <div class="dropdown-divider"></div>
-            <a class="dropdown-item" href="#">Toyhou.se World</a>
-            <a class="dropdown-item" href="#">Discord Server</a>
           </div>
         </li>
 

--- a/index.html
+++ b/index.html
@@ -109,19 +109,6 @@
 
       </div>
 
-      <!-- Social Media Links
-    <!-- --------------------------------------------------------------- -->
-      <hr class="my-4">
-      <div class="text-center mb-md-n4 font-weight-bold">
-
-        <a class="mx-3" href="#"><i class="fas fa-floppy-disk fa-fw mr-1"></i> Toyhou.se</a>
-        <a class="mx-3" href="#"><i class="fab fa-discord fa-fw mr-1"></i> Discord</a>
-        <a class="mx-3" href="#"><i class="fab fa-twitter fa-fw mr-1"></i> Twitter </a>
-        <a class="mx-3" href="#"><i class="fab fa-tumblr fa-fw mr-1"></i> Tumblr</a>
-        <a class="mx-3" href="#"><i class="fas fa-cloud fa-fw mr-1"></i> BlueSky</a>
-
-      </div>
-
     </div>
       
     <!-- Designs

--- a/index.html
+++ b/index.html
@@ -90,15 +90,6 @@
         </div>
 
         <div class="col-lg-4 col-md-6 p-1">
-          <h5>Community</h5>
-          <div class="px-3">
-            <a class="btn btn-primary d-block mb-1" href="#">Toyhou.se</a>
-            <a class="btn btn-primary d-block mb-1" href="#">Discord</a>
-            <a class="btn btn-primary d-block mb-1" href="prompts.html">Prompts</a>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 p-1">
           <h5>Resources</h5>
           <div class="px-3">
             <a class="btn btn-primary d-block mb-1" href="#">Help Desk</a>

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
       <hr class="my-4">
       <div class="row no-gutters m-n1 mb-n2">
 
-        <div class="col-lg-4 p-1">
+        <div class="col-lg-6 p-1">
           <h5>About</h5>
           <div class="px-3">
             <a class="btn btn-primary d-block mb-1" href="world.html">World</a>
@@ -89,7 +89,7 @@
           </div>
         </div>
 
-        <div class="col-lg-4 col-md-6 p-1">
+        <div class="col-lg-6 p-1">
           <h5>Resources</h5>
           <div class="px-3">
             <a class="btn btn-primary d-block mb-1" href="#">Help Desk</a>


### PR DESCRIPTION
## 관련 issue

#5 

## 내용 요약

디스코드와 토이하우스로 연결되는 하이퍼링크를 삭제했습니다

## 변경 사항

- `header.html`에서 디코/토하 하이퍼링크 삭제
- `index.html`에서 최상단 박스 하단 Social Links 삭제
- `index.html`에 Links에서 Community 부분 삭제

## 참고 자료
#### 이전
<img width="2559" height="1377" alt="image" src="https://github.com/user-attachments/assets/95a3d3ce-be9e-4ad8-98ae-97dedadfe13d" />
#### 이후
<img width="2559" height="1333" alt="image" src="https://github.com/user-attachments/assets/6fd3c730-653c-4e3b-9b44-2ed9a83af74d" />
